### PR TITLE
Alternate mantras

### DIFF
--- a/app.js
+++ b/app.js
@@ -48,9 +48,13 @@ function chant(mantra) {
 // chant the mantra every 9 seconds
 // this will equal approximately 10,000 chants per 24 hours
 // enlightenment will be reached in 100 days
+
+var odd = false;
+
 setInterval(function() {
 	try {
-		chant(mantra)
+		chant(mantra + (odd ? " " : ""))
+		odd = ! odd;
 	}
 	catch(err) {
 		console.log(err)


### PR DESCRIPTION
The Twitter error only validates against the previous status update, so alternating with a simple trailing space will allow for each update to not "duplicate" the most recent one.